### PR TITLE
[Fix][Spider] Cards cannot be moved to empty spots

### DIFF
--- a/Solitaire/ViewModels/Pages/SpiderSolitaireViewModel.cs
+++ b/Solitaire/ViewModels/Pages/SpiderSolitaireViewModel.cs
@@ -201,10 +201,11 @@ public partial class SpiderSolitaireViewModel : CardGameViewModel
         PlayingCardViewModel card, bool checkOnly = false)
     {
         //  The trivial case is where from and to are the same.
-        if (from.SequenceEqual(to))
+        if (ReferenceEquals(from, to))
             return false;
-        
-        if (to.SequenceEqual(Stock))
+
+        // Don't allow player to move cards to the Stock
+        if (ReferenceEquals(to, Stock))
             return false;
         
         //  This is the complicated operation.


### PR DESCRIPTION
When playing Spider, after there are no more cards in the stack, it becomes impossible to move cards into empty slots. 

This commit fixes the issue by making sure the game logic compares the source and destination by reference, instead of using the number of cards in source and destination.

It should also fix issue #22